### PR TITLE
Remove check for number of template variables

### DIFF
--- a/R/GenerateHITsFromTemplate.R
+++ b/R/GenerateHITsFromTemplate.R
@@ -3,8 +3,6 @@ function (template, input, filenames = NULL, write.files = FALSE) {
     if(!grepl("\\$\\{.+\\}", template))
         template <- readLines(template, warn = FALSE)
     HITs <- list()
-    if(!length(grep("\\$\\{", template)) == ncol(input)) 
-        stop("Number of input variables does not match variables in template")
     if(!is.null(filenames)) {
         if(!length(filenames) == dim(input)[1]) 
             stop("Number of inputs != length(filenames)")

--- a/inst/templates/htmlquestion2.xml
+++ b/inst/templates/htmlquestion2.xml
@@ -7,8 +7,8 @@
  <body>
   <form name='mturk_form' method='post' id='mturk_form' action='https://www.mturk.com/mturk/externalSubmit'>
   <input type='hidden' value='' name='assignmentId' id='assignmentId'/>
-  <h1>${hitvariable}</h1>
-  <p>${hittext}</p>
+  <h1>${hittitle}</h1>
+  <p>${hitvariable}</p>
   <p>What do you think?</p>
   <p><textarea name='comment' cols='80' rows='3'></textarea></p>
   <p><input type='submit' id='submitButton' value='Submit' /></p></form>


### PR DESCRIPTION
This code (removed in 8bf3b34) makes two incorrect assumptions - that there is a 1 to 1 mapping of input variables and that each template variable occurs only once on each line.

This works: (from examples)

```r
temp <- system.file("templates/htmlquestion2.xml", package = "MTurkR")

a <- data.frame(hittitle = c("HIT title 1","HIT title 2","HIT title 3"),
                hitvariable = c("HIT text 1","HIT text 2","HIT text 3"), 
                stringsAsFactors=FALSE)

temps <- GenerateHITsFromTemplate(template = temp, input = a)
## works
```

This doesn't work (but should):

```r
temp_string <- paste(readLines(temp), collapse="")
temps <- GenerateHITsFromTemplate(template = temp_string, input = a)
```

74ea23f also fixes the template XML to match the example in [GenerateHITsFromTemplate.Rd](https://github.com/leeper/MTurkR/blob/master/man/GenerateHITsFromTemplate.Rd).